### PR TITLE
Create a libbz2.so.1 symlink

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -11,6 +11,9 @@ make install PREFIX=${PREFIX} CFLAGS="${CFLAGS}" CC="${USED_CC}"
 if [[ ${target_platform} =~ .*linux.* ]]; then
   make -f Makefile-libbz2_so CFLAGS="${CFLAGS}" CC="${USED_CC}"
   ln -s libbz2.so.${PKG_VERSION} libbz2.so
+  # The soname is libbz2.so.1.0, so nothing should use libbz2.so.1, but
+  # some tools still do.
+  ln -s libbz2.so.${PKG_VERSION} libbz2.so.1
   cp -d libbz2.so* ${PREFIX}/lib/
 elif [[ ${target_platform} == "osx-64" ]]; then
   ${USED_CC} -shared -Wl,-install_name -Wl,libbz2.dylib -o libbz2.${PKG_VERSION}.dylib blocksort.o huffman.o crctable.o randtable.o compress.o decompress.o bzlib.o

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - bzip2recover-CVE-2016-3189.patch
 
 build:
-  number: 1002
+  number: 1003
   run_exports:
     - {{ pin_subpackage('bzip2') }}
 
@@ -46,6 +46,8 @@ test:
     - test -f ${PREFIX}/include/bzlib.h  # [unix]
     - test -f ${PREFIX}/lib/libbz2.a  # [unix]
     - test -f ${PREFIX}/lib/libbz2.so  # [linux]
+    - test -f ${PREFIX}/lib/libbz2.so.1  # [linux]
+    - test -f ${PREFIX}/lib/libbz2.so.1.0  # [linux]
     - test -f ${PREFIX}/lib/libbz2.dylib  # [osx]
     - if not exist %LIBRARY_INC%\\bzlib.h exit 1  # [win]
     - if not exist %LIBRARY_LIB%\\bzip2.lib exit 1  # [win]


### PR DESCRIPTION
The soname of Bzip2 is libbz2.so.1.0, so this is what tools should use
when linking against bz2. However, some tools incorrectly use
"libbz2.so.1". By providing this symlink, we can make them work.

(Apparently, using a soname with major.minor is somewhat unusual and the
normal way would indeed have been to use libbz2.so.1.)

Debian does this as well in their bzip2 package, see
https://salsa.debian.org/debian/bzip2/blob/0c9335755bcd9519bfc36cf57eb987603b013f46/debian/rules#L73

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a fork of the feedstock to propose changes
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
